### PR TITLE
Transformer v2: decoder-style architecture with per-layer goal conditioning

### DIFF
--- a/fast_td3/fast_td3/actors/transformer/transformer_v2.py
+++ b/fast_td3/fast_td3/actors/transformer/transformer_v2.py
@@ -4,20 +4,66 @@ import torch.nn as nn
 from fast_td3.robots.graph_builder import GraphBuilder
 
 
+class DecoderLayer(nn.Module):
+    """
+    Single decoder-style transformer layer with pre-norm:
+      Pre-norm → Self-attention (joints attend to each other)
+      Pre-norm → Cross-attention (joints query object/goal token)
+      Pre-norm → FFN (4× width)
+    """
+
+    def __init__(self, hidden_nf: int, num_heads: int, dropout: float, act_fn: nn.Module):
+        super().__init__()
+        self.self_attn_norm = nn.LayerNorm(hidden_nf)
+        self.self_attn = nn.MultiheadAttention(
+            hidden_nf, num_heads, dropout=dropout, batch_first=True
+        )
+        self.cross_attn_norm = nn.LayerNorm(hidden_nf)
+        self.cross_attn = nn.MultiheadAttention(
+            hidden_nf, num_heads, dropout=dropout, batch_first=True
+        )
+        self.ffn_norm = nn.LayerNorm(hidden_nf)
+        self.ffn = nn.Sequential(
+            nn.Linear(hidden_nf, hidden_nf * 4),
+            act_fn,
+            nn.Dropout(dropout),
+            nn.Linear(hidden_nf * 4, hidden_nf),
+            nn.Dropout(dropout),
+        )
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor, context: torch.Tensor) -> torch.Tensor:
+        # Self-attention (pre-norm)
+        h = self.self_attn_norm(x)
+        h, _ = self.self_attn(h, h, h)
+        x = x + self.drop(h)
+
+        # Cross-attention: joints query object token (pre-norm)
+        h = self.cross_attn_norm(x)
+        h, _ = self.cross_attn(h, context, context)
+        x = x + self.drop(h)
+
+        # FFN (pre-norm)
+        x = x + self.ffn(self.ffn_norm(x))
+
+        return x
+
+
 class TransformerV2(nn.Module):
     """
-    Transformer-based actor with hierarchical attention: joints-only encoder + cross-attention.
-    
-    Architecture:
-    1. Project joint (5d) and object features to hidden_nf
-    2. Add type embeddings (joint vs object tokens) + positional embeddings to joints only
-    3. Apply n-layer self-attention transformer to joints only
-    4. Cross-attention: joints query object node for global context
-    5. Per-joint action head
-    
-    Key improvement: Joints first attend to each other, then explicitly query the object
-    node for global context through cross-attention. This creates a clearer hierarchy where
-    object information is integrated as context rather than being mixed equally in self-attention.
+    Decoder-style transformer actor: joints attend to each other AND query the
+    object/goal token at every layer (not just at the end).
+
+    Architecture per layer:
+      Pre-norm → Self-attention (joints only)
+      Pre-norm → Cross-attention (joints query goal token)
+      Pre-norm → FFN (4× hidden)
+
+    Compared to the previous version:
+    - Goal conditioning at every layer (not just a single cross-attn after all self-attn)
+    - Pre-norm for training stability
+    - FFN width 4× (standard transformer practice)
+    - act_fn used consistently throughout
     """
 
     def __init__(
@@ -35,20 +81,6 @@ class TransformerV2(nn.Module):
         num_heads=4,
         dropout=0.1,
     ):
-        """
-        :param in_joint_nf: Number of features for joint nodes (pos, vel, x, y, z) = 5
-        :param in_object_nf: Number of features for object/global token (env-specific)
-        :param out_node_nf: Output dimension per node (unused in this architecture)
-        :param hidden_nf: Hidden dimension for embeddings and transformer
-        :param device: Device (e.g. 'cpu', 'cuda:0',...)
-        :param batch_size: Batch size for vectorized environments
-        :param act_fn: Activation function
-        :param n_layers: Number of transformer layers
-        :param robot: Robot name for graph builder
-        :param env_name: Environment name
-        :param num_heads: Number of attention heads
-        :param dropout: Dropout rate
-        """
         super().__init__()
         self.hidden_nf = hidden_nf
         self.device = device
@@ -59,101 +91,67 @@ class TransformerV2(nn.Module):
         self.in_object_nf = in_object_nf
         self.object_feature_dim = in_object_nf
         self.num_heads = num_heads
-        
+
         self.graph_builder = GraphBuilder(env_name, batch_size, device, robot)
         self.num_joints = self.graph_builder.robot.num_joints
-        
-        # Joint projection: 5d -> hidden_nf
+
+        # Joint projection: in_joint_nf → hidden_nf
         self.joint_projection = nn.Sequential(
             nn.Linear(in_joint_nf, hidden_nf),
             act_fn,
         )
-        
-        # Object projection: object_feature_dim -> hidden_nf
+
+        # Object projection: in_object_nf → hidden_nf
         self.object_projection = nn.Sequential(
             nn.Linear(in_object_nf, hidden_nf),
             act_fn,
         )
-        
-        # Learnable positional embeddings for joints only
+
+        # Learnable positional embeddings for joints
         self.positional_embeddings = nn.Parameter(
             torch.randn(self.num_joints, hidden_nf) * 0.02
         )
-        
-        # Type embedding to mark joint tokens
-        self.joint_type_embedding = nn.Parameter(
-            torch.randn(1, 1, hidden_nf) * 0.02
-        )
-        
-        # Transformer encoder for joints only
-        transformer_layer = nn.TransformerEncoderLayer(
-            d_model=hidden_nf,
-            nhead=num_heads,
-            dim_feedforward=hidden_nf * 2,
-            dropout=dropout,
-            batch_first=True,
-            activation="relu",
-        )
-        self.transformer = nn.TransformerEncoder(
-            transformer_layer,
-            num_layers=n_layers,
-        )
-        
-        # Cross-attention: joints query, object provides context
-        self.joint_to_object_cross_attn = nn.MultiheadAttention(
-            embed_dim=hidden_nf,
-            num_heads=num_heads,
-            dropout=dropout,
-            batch_first=True,
-        )
-        self.cross_attn_norm = nn.LayerNorm(hidden_nf)
-        
-        # Per-joint action head: hidden_nf -> hidden_nf -> 1
+
+        # n decoder layers: each does self-attn + cross-attn + FFN
+        self.layers = nn.ModuleList([
+            DecoderLayer(hidden_nf, num_heads, dropout, act_fn)
+            for _ in range(n_layers)
+        ])
+
+        # Final layer-norm before action head
+        self.final_norm = nn.LayerNorm(hidden_nf)
+
+        # Per-joint action head
         self.action_head = nn.Sequential(
             nn.Linear(hidden_nf, hidden_nf),
             act_fn,
             nn.Linear(hidden_nf, 1),
             nn.Tanh(),
         )
-        
+
         self.to(device)
 
     def forward(self, obs: torch.Tensor) -> torch.Tensor:
-        """
-        Process observations through joints-only transformer + cross-attention.
-        
-        Architecture:
-        1. Project features
-        2. Add type and positional embeddings to joints only
-        3. Apply self-attention transformer to joints only (no object in self-attention)
-        4. Cross-attention: joints query object for global context
-        5. Generate actions from contextualized joint features
-        """
         batch_size = obs.shape[0]
         h_objects = obs[:, :self.object_feature_dim].unsqueeze(1)
-        h_joints = obs[:, self.object_feature_dim:].view(batch_size, self.num_joints, self.in_joint_nf)
-
-        # Step 1: Project features to hidden dimension
-        joint_embeddings = self.joint_projection(h_joints)
-        object_embeddings = self.object_projection(h_objects)
-        
-        # Step 2: Add type and positional embeddings to joints only
-        joint_embeddings = joint_embeddings + self.joint_type_embedding
-        joint_embeddings = joint_embeddings + self.positional_embeddings.unsqueeze(0)
-        
-        # Step 3: Apply self-attention transformer to joints only
-        joint_output = self.transformer(joint_embeddings)
-        
-        # Step 4: Cross-attention - joints query object for global context
-        joint_contextualized, _ = self.joint_to_object_cross_attn(
-            query=joint_output,
-            key=object_embeddings,
-            value=object_embeddings,
+        h_joints = obs[:, self.object_feature_dim:].view(
+            batch_size, self.num_joints, self.in_joint_nf
         )
-        joint_output = self.cross_attn_norm(joint_output + joint_contextualized)
-        
-        # Step 5: Generate actions from contextualized joint features
-        actions = self.action_head(joint_output)
-        actions = actions.squeeze(-1)
-        
+
+        # Project to hidden dimension
+        joint_embeddings = self.joint_projection(h_joints)
+        object_embeddings = self.object_projection(h_objects)  # (B, 1, hidden_nf)
+
+        # Add positional embeddings to joints
+        joint_embeddings = joint_embeddings + self.positional_embeddings.unsqueeze(0)
+
+        # Pass through decoder layers (goal context at every layer)
+        x = joint_embeddings
+        for layer in self.layers:
+            x = layer(x, object_embeddings)
+
+        x = self.final_norm(x)
+
+        # Per-joint action
+        actions = self.action_head(x).squeeze(-1)
         return actions

--- a/fast_td3/model_config/transformer_v2.json
+++ b/fast_td3/model_config/transformer_v2.json
@@ -1,6 +1,6 @@
 {
-    "hidden_dim": 72,
-    "n_layers": 2,
+    "hidden_dim": 84,
+    "n_layers": 3,
     "act_fn": "silu",
     "num_heads": 4,
     "dropout": 0.0


### PR DESCRIPTION
## Summary

- **Decoder-style blocks**: replaces the single post-hoc cross-attention with a `DecoderLayer` (self-attn → cross-attn → FFN) repeated at every layer, so joints query the goal token at each depth rather than only at the end
- **Pre-norm**: LayerNorm applied before each sub-layer for more stable training
- **4× FFN width**: increased from 2× to 4× hidden_nf (standard transformer practice)
- **Consistent act_fn**: SiLU now used throughout (was hardcoded `relu` inside `TransformerEncoderLayer`)
- **Config update**: `hidden_dim` 72→84, `n_layers` 2→3 → ~354k total parameters (~350k target)

## Motivation

Analysis of the latest Benchmark New reach-task runs showed transformer_v2 stalled at 9,796 return (target: 12,000) and ran 3.2× slower than MLP. The root cause was that inner transformer layers were blind to the goal — cross-attention only fired once after all self-attention layers. Making every layer a decoder block ensures the goal signal propagates throughout the network depth.

## Test plan
- [ ] Run `python train.py --env_name h1-reach-v1 --actor_type transformer_v2` and verify it starts without error
- [ ] Confirm `eval_avg_return` trends upward past 12,000 on W&B (Benchmark New project)
- [ ] Check wall-clock runtime is competitive with previous transformer_v2 run (~84k s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)